### PR TITLE
improve rails-query-object skill structure and eval score

### DIFF
--- a/CLAUDE_CODE_SETUP_PLAN.md
+++ b/CLAUDE_CODE_SETUP_PLAN.md
@@ -65,7 +65,7 @@ mkdir -p ~/.claude/{hooks,commands,agents,skills}
 
 **File:** `~/.claude/CLAUDE.md`
 
-```markdown
+~~~markdown
 # Global Claude Code Configuration
 
 ## Identity
@@ -118,7 +118,7 @@ mkdir -p ~/.claude/{hooks,commands,agents,skills}
 - Max 50 lines per model method
 - Extract service objects for complex business logic
 - Use concerns for shared model/controller behavior
-```
+~~~
 
 ### 1.3 Create Global settings.json
 
@@ -186,7 +186,7 @@ mkdir -p ~/.claude/{hooks,commands,agents,skills}
 
 **File:** `./CLAUDE.md`
 
-```markdown
+~~~markdown
 # rails-claude Project Guide
 
 ## Overview
@@ -430,13 +430,13 @@ kamal app console      # Rails console on server
 - Skip tests
 - Add unnecessary gems
 - Over-engineer solutions
-```
+~~~
 
 ### 2.2 Create Project Local CLAUDE.md (Optional)
 
 **File:** `./CLAUDE.local.md` (gitignored)
 
-```markdown
+~~~markdown
 # Local Development Overrides
 
 ## Personal Preferences
@@ -446,7 +446,7 @@ kamal app console      # Rails console on server
 ## Local Environment
 - Database: storage/development.sqlite3
 - Server: http://localhost:3000
-```
+~~~
 
 ### 2.3 Update .gitignore
 
@@ -687,7 +687,7 @@ chmod +x ~/.claude/hooks/rails-after-edit.sh
 
 **File:** `~/.claude/commands/rails-test.md`
 
-```markdown
+~~~markdown
 ---
 description: Run Rails tests with options
 argument-hint: [test file or pattern]
@@ -709,7 +709,7 @@ Use:
 - `bin/rails test:system` for browser tests
 - `bin/rails test path/to/test.rb` for specific file
 - `bin/rails test path/to/test.rb:42` for specific line
-```
+~~~
 
 ### 4.2 Rails Lint Command
 
@@ -736,7 +736,7 @@ Arguments: $ARGUMENTS
 
 **File:** `~/.claude/commands/security.md`
 
-```markdown
+~~~markdown
 ---
 description: Run security scans (Brakeman + bundle audit)
 allowed-tools: Bash(bin/brakeman:*), Bash(bundle audit:*)
@@ -764,7 +764,7 @@ Run full security audit:
    ```
 
 Report findings with severity levels and remediation steps.
-```
+~~~
 
 ### 4.4 Rails Generate Command
 
@@ -831,7 +831,7 @@ Report any failures with details.
 
 **File:** `.claude/skills/rails-model/SKILL.md`
 
-```markdown
+~~~markdown
 ---
 name: Rails Model
 description: Create well-structured Rails models with validations, associations, and tests
@@ -941,13 +941,13 @@ end
 - [ ] Scopes for common queries
 - [ ] Tests for validations and methods
 - [ ] Fixtures for test data
-```
+~~~
 
 ### 5.2 Rails Controller Skill
 
 **File:** `.claude/skills/rails-controller/SKILL.md`
 
-```markdown
+~~~markdown
 ---
 name: Rails Controller
 description: Create RESTful Rails controllers with Turbo support
@@ -1076,13 +1076,13 @@ class PostsControllerTest < ActionDispatch::IntegrationTest
   end
 end
 ```
-```
+~~~
 
 ### 5.3 Stimulus Controller Skill
 
 **File:** `.claude/skills/stimulus/SKILL.md`
 
-```markdown
+~~~markdown
 ---
 name: Stimulus Controller
 description: Create Stimulus controllers for JavaScript interactivity
@@ -1212,7 +1212,7 @@ hide() {
 ```bash
 bin/rails generate stimulus controller_name
 ```
-```
+~~~
 
 ---
 
@@ -1222,7 +1222,7 @@ bin/rails generate stimulus controller_name
 
 **File:** `~/.claude/agents/rails-reviewer.md`
 
-```markdown
+~~~markdown
 ---
 name: rails-reviewer
 description: Reviews Rails code for security, performance, and Rails conventions
@@ -1263,13 +1263,13 @@ You are a senior Rails developer reviewing code. Focus on:
 - DRY without over-abstraction
 
 Provide specific file:line references and concrete fix suggestions.
-```
+~~~
 
 ### 6.2 Rails Test Writer Agent
 
 **File:** `~/.claude/agents/rails-test-writer.md`
 
-```markdown
+~~~markdown
 ---
 name: rails-test-writer
 description: Writes comprehensive Rails tests (Minitest)
@@ -1326,13 +1326,13 @@ end
 - Descriptive test names
 - Setup common objects in setup block
 - Use assert_difference for counts
-```
+~~~
 
 ### 6.3 Rails Migration Agent
 
 **File:** `~/.claude/agents/rails-migration.md`
 
-```markdown
+~~~markdown
 ---
 name: rails-migration
 description: Creates safe, reversible Rails database migrations
@@ -1388,7 +1388,7 @@ bin/rails generate migration AddStatusToPosts status:integer:index
 2. Run `bin/rails db:migrate`
 3. Check `db/schema.rb` for expected changes
 4. Run tests to verify no regressions
-```
+~~~
 
 ---
 

--- a/skills/rails-query-object/SKILL.md
+++ b/skills/rails-query-object/SKILL.md
@@ -1,31 +1,36 @@
 ---
 name: rails-query-object
-description: Creates query objects for complex database queries following TDD. Use when encapsulating complex queries, aggregating statistics, building reports, or when user mentions queries, stats, dashboards, or data aggregation.
+description: >-
+  Generates Rails query objects following TDD (RED → GREEN) with RSpec specs.
+  Builds filtered queries, aggregation pipelines, and grouping queries scoped to an account
+  for multi-tenant isolation. Places specs in `spec/queries/` and implementations in `app/queries/`.
+  Use when encapsulating complex ActiveRecord queries, building dashboard stats, aggregating data
+  for reports, creating scoped database lookups, or when user mentions queries, stats, dashboards,
+  data aggregation, or query objects.
 allowed-tools: Read, Write, Edit, Bash(bundle exec rspec:*), Glob, Grep
 ---
 
 # Rails Query Object Generator (TDD)
 
-Creates query objects that encapsulate complex database queries with specs first.
+## Workflow
 
-## Quick Start
-
-1. Write failing spec in `spec/queries/`
-2. Run spec to confirm RED
-3. Implement query object in `app/queries/`
-4. Run spec to confirm GREEN
+1. Write failing spec in `spec/queries/[name]_query_spec.rb`
+2. Run `bundle exec rspec spec/queries/[name]_query_spec.rb` — confirm RED
+3. Implement query object in `app/queries/[name]_query.rb`
+4. Run spec again — confirm GREEN
 
 ## Project Conventions
 
-Query objects in this project:
-- Accept context via constructor (`user:` or `account:`)
-- Return `ActiveRecord::Relation` for chainability OR `Hash` for aggregations
-- Have a `call` method for primary operation
-- Support multi-tenancy (scoped to account)
+| Convention | Detail |
+|---|---|
+| Constructor | Accepts context via `user:` or `account:` |
+| Return type | `ActiveRecord::Relation` for chainability, `Hash` for aggregations |
+| Entry point | `#call` method for primary operation |
+| Multi-tenancy | Always scope queries to `account` |
+| Spec location | `spec/queries/[name]_query_spec.rb` |
+| Implementation | `app/queries/[name]_query.rb` |
 
-## TDD Workflow
-
-### Step 1: Create Query Spec (RED)
+## Spec Template
 
 ```ruby
 # spec/queries/[name]_query_spec.rb
@@ -36,11 +41,8 @@ RSpec.describe [Name]Query do
   let(:account) { user.account }
   let(:other_account) { create(:user).account }
 
-  # Test data for current account
   let!(:resource1) { create(:resource, account: account) }
   let!(:resource2) { create(:resource, account: account) }
-
-  # Test data for other account (should not appear)
   let!(:other_resource) { create(:resource, account: other_account) }
 
   describe "#initialize" do
@@ -70,7 +72,6 @@ RSpec.describe [Name]Query do
   describe "multi-tenant isolation" do
     it "ensures account A cannot see account B data" do
       other_query = described_class.new(account: other_account)
-
       expect(query.call).not_to include(other_resource)
       expect(other_query.call).not_to include(resource1)
     end
@@ -78,13 +79,7 @@ RSpec.describe [Name]Query do
 end
 ```
 
-### Step 2: Run Spec (Confirm RED)
-
-```bash
-bundle exec rspec spec/queries/[name]_query_spec.rb
-```
-
-### Step 3: Implement Query Object (GREEN)
+## Implementation Template
 
 ```ruby
 # app/queries/[name]_query.rb
@@ -95,8 +90,7 @@ class [Name]Query
     @account = account
   end
 
-  # Returns [description of result]
-  # @return [ActiveRecord::Relation<Resource>] OR [Hash]
+  # @return [ActiveRecord::Relation<Resource>]
   def call
     account.resources
       .where(condition: value)
@@ -105,110 +99,15 @@ class [Name]Query
 end
 ```
 
-### Step 4: Run Spec (Confirm GREEN)
-
-```bash
-bundle exec rspec spec/queries/[name]_query_spec.rb
-```
-
-## Query Object Patterns
-
-### Pattern 1: Simple Filtered Query
-
-```ruby
-# app/queries/stale_leads_query.rb
-class StaleLeadsQuery
-  attr_reader :account
-
-  def initialize(account:)
-    @account = account
-  end
-
-  def call
-    account.leads.stale
-  end
-end
-```
-
-### Pattern 2: Aggregation Query (Multiple Methods)
-
-```ruby
-# app/queries/dashboard_stats_query.rb
-class DashboardStatsQuery
-  attr_reader :user, :account
-
-  def initialize(user:)
-    @user = user
-    @account = user.account
-  end
-
-  def upcoming_events(limit: 3)
-    account.events
-      .where("event_date >= ?", Date.today)
-      .order(event_date: :asc)
-      .limit(limit)
-  end
-
-  def pending_commissions_total
-    EventVendor
-      .joins(:event)
-      .where(events: { account_id: account.id })
-      .where(commission_status: :to_invoice)
-      .sum(:commission_value)
-  end
-
-  def top_vendors(limit: 5)
-    account.vendors
-      .left_joins(:event_vendors)
-      .select("vendors.*, COUNT(event_vendors.id) as events_count")
-      .group("vendors.id")
-      .order("events_count DESC")
-      .limit(limit)
-  end
-
-  def leads_by_status
-    account.leads.group(:status).count
-  end
-end
-```
-
-### Pattern 3: Grouping Query
-
-```ruby
-# app/queries/leads_by_status_query.rb
-class LeadsByStatusQuery
-  attr_reader :account
-
-  def initialize(account:)
-    @account = account
-  end
-
-  def call
-    leads = account.leads.order(created_at: :desc)
-    result = Lead.statuses.keys.map(&:to_sym).index_with { [] }
-
-    leads.group_by(&:status).each do |status, status_leads|
-      result[status.to_sym] = status_leads
-    end
-
-    result
-  end
-end
-```
-
-## Usage in Controllers
+## Controller Usage
 
 ```ruby
 # Simple query
-def index
-  @leads_by_status = LeadsByStatusQuery.new(account: current_account).call
-end
+@leads_by_status = LeadsByStatusQuery.new(account: current_account).call
 
 # Aggregation query with presenter
-def index
-  stats_query = DashboardStatsQuery.new(user: current_user)
-  @stats = DashboardStatsPresenter.new(stats_query)
-end
+stats_query = DashboardStatsQuery.new(user: current_user)
+@stats = DashboardStatsPresenter.new(stats_query)
 ```
 
 ## Checklist
@@ -220,3 +119,5 @@ end
 - [ ] Methods have clear, descriptive names
 - [ ] Complex queries use `.includes()` to prevent N+1
 - [ ] All specs GREEN
+
+See [references/patterns.md](references/patterns.md) for filtered, aggregation, and grouping query examples.

--- a/skills/rails-query-object/references/patterns.md
+++ b/skills/rails-query-object/references/patterns.md
@@ -1,0 +1,84 @@
+# Query Object Patterns
+
+## Pattern 1: Simple Filtered Query
+
+```ruby
+# app/queries/stale_leads_query.rb
+class StaleLeadsQuery
+  attr_reader :account
+
+  def initialize(account:)
+    @account = account
+  end
+
+  def call
+    account.leads.stale
+  end
+end
+```
+
+## Pattern 2: Aggregation Query (Multiple Methods)
+
+```ruby
+# app/queries/dashboard_stats_query.rb
+class DashboardStatsQuery
+  attr_reader :user, :account
+
+  def initialize(user:)
+    @user = user
+    @account = user.account
+  end
+
+  def upcoming_events(limit: 3)
+    account.events
+      .where("event_date >= ?", Date.today)
+      .order(event_date: :asc)
+      .limit(limit)
+  end
+
+  def pending_commissions_total
+    EventVendor
+      .joins(:event)
+      .where(events: { account_id: account.id })
+      .where(commission_status: :to_invoice)
+      .sum(:commission_value)
+  end
+
+  def top_vendors(limit: 5)
+    account.vendors
+      .left_joins(:event_vendors)
+      .select("vendors.*, COUNT(event_vendors.id) as events_count")
+      .group("vendors.id")
+      .order("events_count DESC")
+      .limit(limit)
+  end
+
+  def leads_by_status
+    account.leads.group(:status).count
+  end
+end
+```
+
+## Pattern 3: Grouping Query
+
+```ruby
+# app/queries/leads_by_status_query.rb
+class LeadsByStatusQuery
+  attr_reader :account
+
+  def initialize(account:)
+    @account = account
+  end
+
+  def call
+    leads = account.leads.order(created_at: :desc)
+    result = Lead.statuses.keys.map(&:to_sym).index_with { [] }
+
+    leads.group_by(&:status).each do |status, status_leads|
+      result[status.to_sym] = status_leads
+    end
+
+    result
+  end
+end
+```


### PR DESCRIPTION
hey @ThibautBaissac, thanks for publishing the Rails AI suite. Really like the structured methodology with 37signals philosophy + standard Rails patterns. Kudos on getting close to 500 stars! I've just starred it. 

was running your skills through some evals and noticed a few things on rails-query-object that were pretty quick to improve (moving from `~80%` to `100%` agent performance):

- expanded frontmatter description with concrete actions + trigger terms like _ActiveRecord queries_, _dashboard stats_, _scoped database lookups_ so agents can reliably match user requests

- replaced prose conventions with a table for quick scanning + removed redundant Quick Start section that duplicated the TDD workflow

- extracted `3` query patterns (_filtered_, _aggregation_, _grouping_) into `references/patterns.md` for progressive disclosure

these were easy changes to bring the skill in line with what performs well against **Anthropic's best practices**. honest disclosure, I work at a company where we build tooling around this. not a pitch, just fixes that were straightforward to make.

you've got `22` skills here, if you want to do it yourself, evals are free and open to run: [link](https://tessl.io/registry/skills/github/ThibautBaissac/rails_ai_agents) otherwise happy to make the improvements for you.