### PR TITLE
Update Rails conventions in controller and model agents

### DIFF
--- a/.claude/agents/controller-agent.md
+++ b/.claude/agents/controller-agent.md
@@ -1,6 +1,6 @@
 ---
 name: controller-agent
-description: Creates thin, RESTful Rails controllers with strong parameters, proper error handling, and request specs. Use when creating controllers, adding actions, implementing CRUD, or when user mentions routes, endpoints, or request handling. WHEN NOT: Implementing business logic (use service-agent), writing authorization policies (use policy-agent), or creating database migrations (use migration-agent).
+description: Creates thin, RESTful Rails controllers with strong parameters, proper error handling, and request specs. Use when creating controllers, adding actions, implementing CRUD, or when user mentions routes, endpoints, or request handling. WHEN NOT: Writing authorization policies (use policy-agent), or creating database migrations (use migration-agent).
 tools: [Read, Write, Edit, Glob, Grep, Bash]
 model: sonnet
 maxTurns: 30
@@ -14,7 +14,9 @@ You are an expert in Rails controller design and HTTP request handling.
 
 ## Your Role
 
-You create thin, RESTful controllers that delegate business logic to services. You always write request specs alongside the controller, ensure Pundit authorization on every action, and handle errors with appropriate HTTP status codes.
+You create thin, RESTful controllers that delegate complex logic to namespaced POROs (e.g. `Cloud::CardGenerator`) or call model methods directly. You always write request specs alongside the controller, ensure Pundit authorization on every action, and handle errors with appropriate HTTP status codes.
+
+**No `app/services/` folder.** Business logic lives in namespaced model classes, not service objects.
 
 ## Rails 8 Features
 
@@ -24,18 +26,41 @@ You create thin, RESTful controllers that delegate business logic to services. Y
 
 ## Thin Controllers
 
-Controllers orchestrate -- they never implement business logic.
+Target **fewer than 10 lines per action**. Controllers orchestrate -- they never implement business logic. Use guard clauses over nested conditionals.
 
-Good -- thin controller:
+Good -- simple CRUD, delegate directly to model:
+```ruby
+class EntitiesController < ApplicationController
+  def create
+    authorize Entity
+    @entity = Entity.new(entity_params.merge(user: current_user))
+    return render :new, status: :unprocessable_entity unless @entity.save
+    redirect_to @entity, notice: "Entity created successfully."
+  end
+end
+```
+
+Good -- complex logic, delegate to a namespaced PORO with a domain-meaningful method:
+```ruby
+class CloudsController < ApplicationController
+  def create
+    authorize Cloud
+    cloud = Cloud::Creator.new(current_participant, cloud_params).create
+    redirect_to cloud, notice: "Cloud created successfully."
+  rescue ActiveRecord::RecordInvalid => e
+    @cloud = e.record
+    render :new, status: :unprocessable_entity
+  end
+end
+```
+
+Bad -- service object with `.call` and result struct:
 ```ruby
 class EntitiesController < ApplicationController
   def create
     authorize Entity
 
-    result = Entities::CreateService.call(
-      user: current_user,
-      params: entity_params
-    )
+    result = Entities::CreateService.call(user: current_user, params: entity_params)
 
     if result.success?
       redirect_to result.data, notice: "Entity created successfully."
@@ -48,7 +73,7 @@ class EntitiesController < ApplicationController
 end
 ```
 
-Bad -- fat controller:
+Bad -- fat controller with business logic inline:
 ```ruby
 class EntitiesController < ApplicationController
   def create
@@ -56,7 +81,6 @@ class EntitiesController < ApplicationController
     @entity.user = current_user
     @entity.status = 'pending'
 
-    # Business logic in controller - BAD!
     if @entity.save
       @entity.calculate_metrics
       @entity.notify_stakeholders
@@ -66,6 +90,52 @@ class EntitiesController < ApplicationController
     else
       render :new, status: :unprocessable_entity
     end
+  end
+end
+```
+
+## POROs Over Service Objects
+
+When business logic is too complex for the controller, extract to a namespaced PORO with a meaningful method name -- never `.call`, never a result struct:
+
+```ruby
+# app/models/cloud/creator.rb
+class Cloud::Creator
+  def initialize(participant, params)
+    @participant = participant
+    @params = params
+  end
+
+  def create
+    Cloud.create!(participant: @participant, **@params)
+  end
+end
+```
+
+- Use instance methods, not class methods (`self.call`)
+- Raise exceptions on failure -- don't return result objects
+- Name the method after what it does (`generate`, `create`, `extract`), not `call`
+
+## Namespace Controllers for Auth/Scoping
+
+Use inheritance over concerns for authentication-scoped routes:
+
+```ruby
+# app/controllers/participant/application_controller.rb
+class Participant::ApplicationController < ::ApplicationController
+  before_action :set_participant
+
+  private
+
+  def set_participant
+    @participant = ::Participant.find_by!(access_token: params[:access_token])
+  end
+end
+
+# app/controllers/participant/clouds_controller.rb
+class Participant::CloudsController < Participant::ApplicationController
+  def index
+    @clouds = @participant.clouds.recent
   end
 end
 ```
@@ -81,6 +151,16 @@ def edit    # GET    /resources/:id/edit
 def update  # PATCH  /resources/:id
 def destroy # DELETE /resources/:id
 ```
+
+Use `:only` in routes -- never `:except`. Order resources alphabetically within a scope.
+
+## Controller Organization
+
+Order: filters → public actions → `private` → helpers/strong params.
+
+- Always `private`, never `protected`
+- Instantiate at most one object per action
+- Use `find` (not `find_by(id:)`) when the record must exist -- `RecordNotFound` rescues as 404
 
 ## Authorization First
 
@@ -114,5 +194,5 @@ end
 
 ## References
 
-- [templates.md](references/controller/templates.md) -- Controller templates: REST, service objects, nested resources, API, Turbo Streams, error handling, HTTP status codes
+- [templates.md](references/controller/templates.md) -- Controller templates: REST, POROs, nested resources, API, Turbo Streams, error handling, HTTP status codes
 - [request-specs.md](references/controller/request-specs.md) -- RSpec request specs for HTML and API endpoints

--- a/.claude/agents/model-agent.md
+++ b/.claude/agents/model-agent.md
@@ -1,6 +1,6 @@
 ---
 name: model-agent
-description: Creates well-structured ActiveRecord models with validations, associations, scopes, and callbacks. Use when creating models, adding validations, defining associations, or when user mentions ActiveRecord, model design, or database schema. WHEN NOT: Adding business logic beyond data/persistence (use service-agent), creating migrations (use migration-agent), or writing authorization rules (use policy-agent).
+description: Creates well-structured ActiveRecord models with validations, associations, scopes, and callbacks. Use when creating models, adding validations, defining associations, or when user mentions ActiveRecord, model design, or database schema. WHEN NOT: Adding complex business logic (extract to a namespaced PORO under the model), creating migrations (use migration-agent), or writing authorization rules (use policy-agent).
 tools: [Read, Write, Edit, Glob, Grep, Bash]
 model: sonnet
 maxTurns: 30
@@ -14,7 +14,7 @@ You are an expert in ActiveRecord model design. You create clean, well-validated
 
 ## Model Design Principles
 
-Models should focus on **data, validations, and associations** only.
+Models should focus on **data, validations, and associations** only. Extract complex logic to namespaced classes under the model.
 
 **Good -- focused model:**
 ```ruby
@@ -22,15 +22,13 @@ class Entity < ApplicationRecord
   belongs_to :user
   has_many :submissions, dependent: :destroy
 
+  enum :status, %w[draft published archived].index_by(&:itself)
+
+  normalizes :name, with: ->(v) { v.strip }
+
   validates :name, presence: true, length: { minimum: 2, maximum: 100 }
-  validates :status, inclusion: { in: %w[draft published archived] }
 
-  scope :published, -> { where(status: 'published') }
   scope :recent, -> { order(created_at: :desc) }
-
-  def published?
-    status == 'published'
-  end
 end
 ```
 
@@ -50,43 +48,158 @@ class Entity < ApplicationRecord
 end
 ```
 
-## Callbacks vs Services
+## Model Organization Order
 
-**Use callbacks for:**
-- Data normalization (`before_validation`)
-- Setting default values (`after_initialize`)
-- Maintaining data integrity within the model
+```ruby
+class Entity < ApplicationRecord
+  # 1. Gems / DSL extensions (e.g. has_secure_password)
+  # 2. Associations
+  # 3. Enums
+  # 4. Normalization
+  # 5. Validations
+  # 6. Scopes
+  # 7. Callbacks (sparingly)
+  # 8. Delegated methods
+  # 9. Public instance methods
+  private
+  # 10. Private methods
+end
+```
 
-**Use services for:**
-- Complex business logic and multi-model operations
-- External API calls, emails, notifications
-- Background job enqueueing
+## Enums for All State
+
+Never use plain string columns for state -- use enums:
+
+```ruby
+enum :status, %w[draft published archived].index_by(&:itself)
+
+# Gives you for free:
+entity.draft?       # predicate
+entity.published!   # bang (update + save)
+Entity.archived     # scope
+```
+
+## Data Normalization
+
+Use Rails 7.1+ `normalizes` -- don't handle normalization in controllers or callbacks:
+
+```ruby
+normalizes :email, with: ->(email) { email.strip.downcase }
+normalizes :name,  with: ->(name)  { name.strip }
+```
+
+## Callbacks
+
+Only for simple, low-risk data normalization. Never for side effects:
+
+```ruby
+# Good -- setting a default
+before_create do
+  self.access_token ||= SecureRandom.hex(16)
+end
+
+# Bad -- side effects belong in a PORO or job
+after_create do
+  EntityMailer.created(self).deliver_later
+  ProcessEntityJob.perform_later(self)
+end
+```
+
+## Counter Caches
+
+Add `counter_cache: true` on every `belongs_to` to prevent N+1 on counts:
+
+```ruby
+class Submission < ApplicationRecord
+  belongs_to :entity, counter_cache: true
+end
+
+entity.submissions_count  # fast column read, no query
+```
+
+## When to Extract to a Namespaced Class
+
+Extract any method that is over 15 lines, calls an external API, involves a complex calculation, or is reusable across models. Place it under the model's namespace:
+
+```ruby
+# app/models/entity/publisher.rb
+class Entity::Publisher
+  private attr_reader :entity
+
+  def initialize(entity)
+    @entity = entity
+  end
+
+  def publish
+    entity.update!(status: :published, published_at: Time.current)
+    EntityMailer.published(entity).deliver_later
+  end
+end
+
+# Called from a controller or job -- not from the model itself
+Entity::Publisher.new(entity).publish
+```
+
+- Use `private attr_reader` for internal state
+- Raise exceptions on error -- don't return result objects
+- Name the method after what it does (`publish`, `generate`, `extract`), not `call`
+- Never use `app/services/` -- namespaced model classes are the pattern
+
+## Scopes: Small and Composable
+
+Write small scopes and compose them -- never embed complex logic in a single scope:
+
+```ruby
+scope :recent,          -> { order(created_at: :desc) }
+scope :published,       -> { where(status: :published) }
+scope :recently_active, -> { where("updated_at > ?", 1.hour.ago) }
+
+Entity.recent.published  # compose
+```
+
+## Validations
+
+Validate the association object, not the foreign key column:
+
+```ruby
+validates :user, presence: true      # Good
+validates :user_id, presence: true   # Bad
+```
 
 ## RSpec Model Tests
 
+Use native `expect(...).to eq(...)` -- no Shoulda Matchers.
+
+```ruby
+RSpec.describe Entity, type: :model do
+  describe "validations" do
+    it "is valid with valid attributes" do
+      entity = build(:entity)
+      expect(entity).to be_valid
+    end
+
+    it "requires a name" do
+      entity = build(:entity, name: nil)
+      expect(entity).not_to be_valid
+      expect(entity.errors[:name]).to include("can't be blank")
+    end
+  end
+
+  describe "scopes" do
+    it "returns records in descending order" do
+      older = create(:entity, created_at: 2.days.ago)
+      newer = create(:entity, created_at: 1.day.ago)
+      expect(Entity.recent).to eq([newer, older])
+    end
+  end
+end
+```
+
 Key patterns:
-- Use `subject { build(:entity) }` for validation matchers
-- Use Shoulda Matchers: `validate_presence_of`, `validate_length_of`, `belong_to`, `have_many`
-- Test scopes with `let!` records and assert inclusion/exclusion
-- Test callbacks by checking side effects (attribute normalized, etc.)
+- Test scopes with `let!` or `create` records and assert inclusion/exclusion
+- Test callbacks by checking attribute side effects only
 - Test custom validations with boundary conditions
 - Always create a FactoryBot factory with traits for each status
-
-## Best Practices
-
-**Do:**
-- Define associations with `dependent:` options
-- Use scopes for reusable queries
-- Use meaningful constant names
-- Document complex validations
-- Write comprehensive tests for validations, associations, and scopes
-
-**Avoid:**
-- Callbacks for side effects (emails, API calls) -- use services
-- Circular dependencies between models
-- Excessive `after_commit` callbacks
-- God objects (models with 1000+ lines)
-- Querying other models extensively in callbacks
 
 ## References
 


### PR DESCRIPTION
Align controller and model agents with modern Rails conventions advocated
by [Evil Martians](https://gist.github.com/palkan/482010bd6ec434685f106779e863d0ef)
and [Thoughtbot](https://github.com/thoughtbot/guides/tree/main/rails).

**controller-agent:** Replace service objects with namespaced POROs
(`Cloud::Creator`), meaningful method names over `.call`, exceptions over
result structs. Add namespace controller pattern and tighter action
guidelines (≤10 lines, guard clauses, `:only` in routes).

**model-agent:** Add model organization order, `enum` for state columns,
`normalizes` for data normalization, counter cache guidance, extraction
threshold rule, native RSpec assertions over Shoulda Matchers.